### PR TITLE
Exit command: display exit message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting ResearchRoster as requested ...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -158,10 +158,10 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleExit() {
+        // Disable commandBox upon exiting
+        commandBoxPlaceholder.getChildren().get(0).setDisable(true);
         new Thread(() -> {
             try {
-                // Disable commandBox upon exiting
-                commandBoxPlaceholder.getChildren().get(0).setDisable(true);
                 // Display FeedbackToUser for 3 seconds before exiting
                 Thread.sleep(3000);
             } catch (InterruptedException e) {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -2,6 +2,7 @@ package seedu.address.ui;
 
 import java.util.logging.Logger;
 
+import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
@@ -18,8 +19,8 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * The Main Window. Provides the basic application layout containing
- * a menu bar and space where other JavaFX elements can be placed.
+ * The Main Window. Provides the basic application layout containing a menu bar
+ * and space where other JavaFX elements can be placed.
  */
 public class MainWindow extends UiPart<Stage> {
 
@@ -78,6 +79,7 @@ public class MainWindow extends UiPart<Stage> {
 
     /**
      * Sets the accelerator of a MenuItem.
+     *
      * @param keyCombination the KeyCombination value of the accelerator
      */
     private void setAccelerator(MenuItem menuItem, KeyCombination keyCombination) {
@@ -85,18 +87,18 @@ public class MainWindow extends UiPart<Stage> {
 
         /*
          * TODO: the code below can be removed once the bug reported here
-         * https://bugs.openjdk.java.net/browse/JDK-8131666
-         * is fixed in later version of SDK.
+         * https://bugs.openjdk.java.net/browse/JDK-8131666 is fixed in later version of
+         * SDK.
          *
          * According to the bug report, TextInputControl (TextField, TextArea) will
          * consume function-key events. Because CommandBox contains a TextField, and
-         * ResultDisplay contains a TextArea, thus some accelerators (e.g F1) will
-         * not work when the focus is in them because the key event is consumed by
-         * the TextInputControl(s).
+         * ResultDisplay contains a TextArea, thus some accelerators (e.g F1) will not
+         * work when the focus is in them because the key event is consumed by the
+         * TextInputControl(s).
          *
          * For now, we add following event filter to capture such key events and open
-         * help window purposely so to support accelerators even when focus is
-         * in CommandBox or ResultDisplay.
+         * help window purposely so to support accelerators even when focus is in
+         * CommandBox or ResultDisplay.
          */
         getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             if (event.getTarget() instanceof TextInputControl && keyCombination.match(event)) {
@@ -156,11 +158,24 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleExit() {
-        GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),
-                (int) primaryStage.getX(), (int) primaryStage.getY());
-        logic.setGuiSettings(guiSettings);
-        helpWindow.hide();
-        primaryStage.hide();
+        new Thread(() -> {
+            try {
+                // Disable commandBox upon exiting
+                commandBoxPlaceholder.getChildren().get(0).setDisable(true);
+                // Display FeedbackToUser for 3 seconds before exiting
+                Thread.sleep(3000);
+            } catch (InterruptedException e) {
+                ; // Do nothing
+            } finally {
+                Platform.runLater(() -> {
+                    GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),
+                            (int) primaryStage.getX(), (int) primaryStage.getY());
+                    logic.setGuiSettings(guiSettings);
+                    helpWindow.hide();
+                    primaryStage.hide();
+                });
+            }
+        }).start();
     }
 
     public PersonListPanel getPersonListPanel() {


### PR DESCRIPTION
Fixes #42 

The feedbackToUser is passed to the resultDisplay UI, but the application closes too quickly for the feedback to be rendered to the user.

Let's add a 3 second delay upon exit.

Running the delay (and handleExit behaviour) on a separate concurrent thread allows the feedbackToUser to be rendered by FXML.

The duration of the delay (3 seconds) is arbitrarily selected, and can be modified later based on user feedback.

Let's disable the commandBox.

Disabling the commandBox prevents new commands from being executed. As the handleExit behaviour is running concurrently with the application's command execution, a command's behaviour might be interrupted before it completes all its steps. For example, after exiting, the user deletes a person record, but the application closes before the deletion is saved by the storage module.