### PR TITLE
MVP - Gender field

### DIFF
--- a/src/main/java/seedu/address/model/person/Gender.java
+++ b/src/main/java/seedu/address/model/person/Gender.java
@@ -10,19 +10,20 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Gender {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Gender should only be 'F' (Female) or 'M' (Male)";
-    public static final String VALIDATION_REGEX = "^[FM]$";
+            "Gender should only be 'F' / 'f' (Female) or 'M' / 'm' (Male)";
+    public static final String VALIDATION_REGEX = "^[FfMm]$";
     public final String value;
 
     /**
      * Constructs a {@code Gender}.
      *
-     * @param gender A valid gender ('F' or 'M').
+     * @param gender A valid gender ('F', 'f', 'M' or 'm').
+     *               'f' is stored as 'F'; 'm' is stored as 'M'.
      */
     public Gender(String gender) {
         requireNonNull(gender);
         checkArgument(isValidGender(gender), MESSAGE_CONSTRAINTS);
-        this.value = gender;
+        this.value = gender.toUpperCase();
     }
 
     public static boolean isValidGender(String test) {

--- a/src/test/java/seedu/address/model/person/GenderTest.java
+++ b/src/test/java/seedu/address/model/person/GenderTest.java
@@ -1,0 +1,60 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class GenderTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Gender(null));
+    }
+
+    @Test
+    public void constructor_invalidGender_throwsIllegalArgumentException() {
+        String invalidGender = "";
+        assertThrows(IllegalArgumentException.class, () -> new Gender(invalidGender));
+    }
+
+    @Test
+    public void isValidGender() {
+        // null gender
+        assertThrows(NullPointerException.class, () -> Gender.isValidGender(null));
+
+        // invalid gender
+        assertFalse(Gender.isValidGender("")); // empty string
+        assertFalse(Gender.isValidGender(" ")); // spaces only
+        assertFalse(Gender.isValidGender("G")); // invalid character
+        assertFalse(Gender.isValidGender("Female")); // invalid characters
+
+        // valid gender
+        assertTrue(Gender.isValidGender("F"));
+        assertTrue(Gender.isValidGender("M"));
+        assertTrue(Gender.isValidGender("f"));
+        assertTrue(Gender.isValidGender("m"));
+    }
+
+    @Test
+    public void equals() {
+        Gender gender = new Gender("f");
+
+        // same values -> returns true
+        assertTrue(gender.equals(new Gender("F")));
+
+        // same object -> returns true
+        assertTrue(gender.equals(gender));
+
+        // null -> returns false
+        assertFalse(gender.equals(null));
+
+        // different types -> returns false
+        assertFalse(gender.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(gender.equals(new Gender("M")));
+    }
+
+}


### PR DESCRIPTION
Fixes #61 

- Updated the gender field to accept 'f' and 'm' as valid inputs, while saving them internally as 'F' and 'M' respectively.
- Created JUnit testcases for the Gender class.