### PR TITLE
Alpha Version - Find command

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -13,15 +13,18 @@ import java.util.Arrays;
 public class StringUtil {
 
     /**
-     * Returns true if the {@code sentence} contains the {@code word}.
-     *   Ignores case, but a full word match is required.
-     *   <br>examples:<pre>
+     * Returns true if the {@code sentence} contains the {@code word}. Ignores case,
+     * but a full word match is required. <br>
+     * examples:
+     *
+     * <pre>
      *       containsWordIgnoreCase("ABc def", "abc") == true
      *       containsWordIgnoreCase("ABc def", "DEF") == true
      *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
-     *       </pre>
+     * </pre>
+     *
      * @param sentence cannot be null
-     * @param word cannot be null, cannot be empty, must be a single word
+     * @param word     cannot be null, cannot be empty, must be a single word
      */
     public static boolean containsWordIgnoreCase(String sentence, String word) {
         requireNonNull(sentence);
@@ -39,6 +42,31 @@ public class StringUtil {
     }
 
     /**
+     * Returns true if the {@code sentence} contains the {@code substring}. Ignores
+     * case, any substring match is acceptable. <br>
+     * examples:
+     *
+     * <pre>
+     *       containsWordIgnoreCase("ABc def", "abc") == true
+     *       containsWordIgnoreCase("ABc def", "DEF") == true
+     *       containsWordIgnoreCase("ABc def", "AB") == true //is a subtring match
+     * </pre>
+     *
+     * @param sentence  cannot be null
+     * @param substring cannot be null, cannot be empty, must be a single word
+     */
+    public static boolean containsSubstringIgnoreCase(String sentence, String substring) {
+        requireNonNull(sentence);
+        requireNonNull(substring);
+
+        String preppedSubstring = substring.trim();
+        checkArgument(!preppedSubstring.isEmpty(), "Substring parameter cannot be empty");
+        checkArgument(preppedSubstring.split("\\s+").length == 1, "Substring parameter should be a single word");
+
+        return sentence.toLowerCase().contains(preppedSubstring.toLowerCase());
+    }
+
+    /**
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {
@@ -49,10 +77,12 @@ public class StringUtil {
     }
 
     /**
-     * Returns true if {@code s} represents a non-zero unsigned integer
-     * e.g. 1, 2, 3, ..., {@code Integer.MAX_VALUE} <br>
-     * Will return false for any other non-null string input
-     * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
+     * Returns true if {@code s} represents a non-zero unsigned integer e.g. 1, 2,
+     * 3, ..., {@code Integer.MAX_VALUE} <br>
+     * Will return false for any other non-null string input e.g. empty string,
+     * "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a"
+     * (contains letters)
+     *
      * @throws NullPointerException if {@code s} is null.
      */
     public static boolean isNonZeroUnsignedInteger(String s) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,11 +5,11 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.PredicateGroup;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Finds and lists all persons in address book whose field(s) satisfy all
+ * criteria provided. Criteria are given in a {@code PredicateGroup}.
  */
 public class FindCommand extends Command {
 
@@ -20,16 +20,18 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    public static final String MESSAGE_NO_CRITERIA = "At least one criteria to find by must be provided.";
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
+    private final PredicateGroup predicates;
+
+    public FindCommand(PredicateGroup predicates) {
+        this.predicates = predicates;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
+        model.updateFilteredPersonList(predicates);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
@@ -46,13 +48,13 @@ public class FindCommand extends Command {
         }
 
         FindCommand otherFindCommand = (FindCommand) other;
-        return predicate.equals(otherFindCommand.predicate);
+        return predicates.equals(otherFindCommand.predicates);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("predicate", predicate)
+                .add("predicates", predicates)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,24 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GENDER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.AgeContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.DetailsContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.GenderMatchesKeywordsPredicate;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.PredicateGroup;
+import seedu.address.model.person.predicates.StudyGroupsContainKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -14,8 +26,9 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 public class FindCommandParser implements Parser<FindCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the FindCommand
-     * and returns a FindCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the
+     * FindCommand and returns a FindCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
@@ -25,9 +38,43 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_EMAIL, PREFIX_GENDER,
+                PREFIX_AGE, PREFIX_DETAIL, PREFIX_TAG);
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_EMAIL, PREFIX_GENDER, PREFIX_AGE, PREFIX_DETAIL);
+
+        PredicateGroup predicateGroup = new PredicateGroup();
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            String[] nameKeywords = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
+            predicateGroup.add(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            String[] emailKeywords = argMultimap.getValue(PREFIX_EMAIL).get().split("\\s+");
+            predicateGroup.add(new EmailContainsKeywordsPredicate(Arrays.asList(emailKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_GENDER).isPresent()) {
+            String[] genderKeywords = argMultimap.getValue(PREFIX_GENDER).get().split("\\s+");
+            predicateGroup.add(new GenderMatchesKeywordsPredicate(Arrays.asList(genderKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_AGE).isPresent()) {
+            String[] ageKeywords = argMultimap.getValue(PREFIX_AGE).get().split("\\s+");
+            predicateGroup.add(new AgeContainsKeywordsPredicate(Arrays.asList(ageKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            String[] tagKeywords = argMultimap.getValue(PREFIX_TAG).get().split("\\s+");
+            predicateGroup.add(new StudyGroupsContainKeywordsPredicate(Arrays.asList(tagKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_DETAIL).isPresent()) {
+            String[] detailKeywords = argMultimap.getValue(PREFIX_DETAIL).get().split("\\s+");
+            predicateGroup.add(new DetailsContainsKeywordsPredicate(Arrays.asList(detailKeywords)));
+        }
+
+        if (!predicateGroup.isAnyPredicateAdded()) {
+            throw new ParseException(FindCommand.MESSAGE_NO_CRITERIA);
+        }
+
+        return new FindCommand(predicateGroup);
     }
 
 }

--- a/src/main/java/seedu/address/model/person/predicates/AgeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/AgeContainsKeywordsPredicate.java
@@ -1,0 +1,45 @@
+package seedu.address.model.person.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
+
+/**
+ * Tests that a {@code Person}'s {@code Age} matches any of the ages given.
+ */
+public class AgeContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public AgeContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getAge().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AgeContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        AgeContainsKeywordsPredicate otherAgeContainsKeywordsPredicate = (AgeContainsKeywordsPredicate) other;
+        return keywords.equals(otherAgeContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/predicates/DetailsContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/DetailsContainsKeywordsPredicate.java
@@ -1,0 +1,47 @@
+package seedu.address.model.person.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
+
+/**
+ * Tests that a {@code Person}'s {@code Details} matches any of the keywords
+ * given.
+ */
+public class DetailsContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public DetailsContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getDetail().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DetailsContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        DetailsContainsKeywordsPredicate otherDetailContainsKeywordsPredicate =
+                (DetailsContainsKeywordsPredicate) other;
+        return keywords.equals(otherDetailContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/predicates/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/EmailContainsKeywordsPredicate.java
@@ -1,0 +1,46 @@
+package seedu.address.model.person.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
+
+/**
+ * Tests that a {@code Person}'s {@code Email} matches any of the keywords
+ * given.
+ */
+public class EmailContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public EmailContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsSubstringIgnoreCase(person.getEmail().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EmailContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        EmailContainsKeywordsPredicate otherEmailContainsKeywordsPredicate = (EmailContainsKeywordsPredicate) other;
+        return keywords.equals(otherEmailContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/predicates/GenderMatchesKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/GenderMatchesKeywordsPredicate.java
@@ -1,0 +1,46 @@
+package seedu.address.model.person.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
+
+/**
+ * Tests that a {@code Person}'s {@code Gender} matches any of the keywords
+ * given.
+ */
+public class GenderMatchesKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public GenderMatchesKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getGender().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof GenderMatchesKeywordsPredicate)) {
+            return false;
+        }
+
+        GenderMatchesKeywordsPredicate otherGenerderMatchesKeywordsPredicate = (GenderMatchesKeywordsPredicate) other;
+        return keywords.equals(otherGenerderMatchesKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicate.java
@@ -1,10 +1,11 @@
-package seedu.address.model.person;
+package seedu.address.model.person.predicates;
 
 import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
 
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.

--- a/src/main/java/seedu/address/model/person/predicates/PredicateGroup.java
+++ b/src/main/java/seedu/address/model/person/predicates/PredicateGroup.java
@@ -1,0 +1,70 @@
+package seedu.address.model.person.predicates;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
+
+/**
+ * Represents the collection of all {@code Predicate<Person>} criteria to test.
+ */
+public class PredicateGroup implements Predicate<Person> {
+    private List<Predicate<Person>> predicates;
+
+    public PredicateGroup() {
+        this.predicates = new ArrayList<>();
+    }
+
+    /**
+     * Constructs a {@code PredicateGroup} using {@code Predicate<Person>}s
+     * provided.
+     */
+    @SafeVarargs
+    public PredicateGroup(Predicate<Person>... predicates) {
+        // The only arguments that will be passed into this constuctor is of type
+        // `Predicate<Person>` so it is safe to accept Variable Arguments.
+        this.predicates = Arrays.asList(predicates);
+    }
+
+    public void add(Predicate<Person> predicate) {
+        this.predicates.add(predicate);
+    }
+
+    public boolean isAnyPredicateAdded() {
+        return predicates.size() > 0;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return predicates.stream()
+                .allMatch(predicate -> predicate.test(person));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof PredicateGroup)) {
+            return false;
+        }
+
+        PredicateGroup otherPredicateGroup = (PredicateGroup) other;
+        return predicates.stream()
+                .allMatch(predicate -> otherPredicateGroup.predicates.stream()
+                        .anyMatch(otherPredicate -> predicate.equals(otherPredicate)))
+                && otherPredicateGroup.predicates.stream()
+                        .allMatch(otherPredicate -> this.predicates.stream()
+                                .anyMatch(predicate -> otherPredicate.equals(predicate)));
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("predicates", predicates).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/predicates/StudyGroupsContainKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/StudyGroupsContainKeywordsPredicate.java
@@ -1,0 +1,49 @@
+package seedu.address.model.person.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
+
+/**
+ * Tests that a {@code Person}'s {@code StudyGroupTag}s matches any of the
+ * keywords given.
+ */
+public class StudyGroupsContainKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public StudyGroupsContainKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> person.getStudyGroupTags().stream()
+                        .anyMatch(
+                                studyGroup -> StringUtil.containsWordIgnoreCase(studyGroup.studyGroupName, keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof StudyGroupsContainKeywordsPredicate)) {
+            return false;
+        }
+
+        StudyGroupsContainKeywordsPredicate otherStudyGroupsContainKeywordsPredicate =
+                (StudyGroupsContainKeywordsPredicate) other;
+        return keywords.equals(otherStudyGroupsContainKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -18,8 +18,8 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 /**

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -18,10 +18,12 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.PredicateGroup;
 
 /**
- * Contains integration tests (interaction with the Model) for {@code FindCommand}.
+ * Contains integration tests (interaction with the Model) for
+ * {@code FindCommand}.
  */
 public class FindCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
@@ -29,19 +31,19 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        PredicateGroup firstPredicateGroup = new PredicateGroup(new NameContainsKeywordsPredicate(
+                Collections.singletonList("first")));
+        PredicateGroup secondPredicateGroup = new PredicateGroup(new NameContainsKeywordsPredicate(
+                Collections.singletonList("second")));
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        FindCommand findFirstCommand = new FindCommand(firstPredicateGroup);
+        FindCommand findSecondCommand = new FindCommand(secondPredicateGroup);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstPredicateGroup);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -50,16 +52,16 @@ public class FindCommandTest {
         // null -> returns false
         assertFalse(findFirstCommand.equals(null));
 
-        // different person -> returns false
+        // different predicate group -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
     }
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+        PredicateGroup predicateGroup = new PredicateGroup(preparePredicate(" "));
+        FindCommand command = new FindCommand(predicateGroup);
+        expectedModel.updateFilteredPersonList(predicateGroup);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
@@ -67,18 +69,19 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+        PredicateGroup predicateGroup = new PredicateGroup(preparePredicate("Kurz Elle Kunz"));
+        FindCommand command = new FindCommand(predicateGroup);
+        expectedModel.updateFilteredPersonList(predicateGroup);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
     }
 
     @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
-        FindCommand findCommand = new FindCommand(predicate);
-        String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        PredicateGroup predicateGroup = new PredicateGroup(
+                new NameContainsKeywordsPredicate(Arrays.asList("keyword")));
+        FindCommand findCommand = new FindCommand(predicateGroup);
+        String expected = FindCommand.class.getCanonicalName() + "{predicates=" + predicateGroup + "}";
         assertEquals(expected, findCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,12 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GENDER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -23,9 +28,16 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.predicates.AgeContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.DetailsContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.GenderMatchesKeywordsPredicate;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.PredicateGroup;
+import seedu.address.model.person.predicates.StudyGroupsContainKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
+import seedu.address.testutil.FindUtil;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
 
@@ -58,7 +70,8 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+                + INDEX_FIRST_PERSON.getOneBased() + " "
+                + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
 
@@ -70,10 +83,67 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        List<String> generalKeywords = Arrays.asList("foo", "bar", "baz");
+        List<String> genderKeywords = Arrays.asList("m", "F");
+        List<String> ageKeywords = Arrays.asList("12", "34", "56");
+
+        // parse name criteria
+        FindCommand nameCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " "
+                        + FindUtil.getFindCriteria(PREFIX_NAME, generalKeywords));
+        assertEquals(new FindCommand(new PredicateGroup(new NameContainsKeywordsPredicate(generalKeywords))),
+                nameCommand);
+
+        // parse email criteria
+        FindCommand emailCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " "
+                        + FindUtil.getFindCriteria(PREFIX_EMAIL, generalKeywords));
+        assertEquals(new FindCommand(new PredicateGroup(new EmailContainsKeywordsPredicate(generalKeywords))),
+                emailCommand);
+
+        // parse gender criteria
+        FindCommand genderCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " "
+                        + FindUtil.getFindCriteria(PREFIX_GENDER, genderKeywords));
+        assertEquals(new FindCommand(new PredicateGroup(new GenderMatchesKeywordsPredicate(genderKeywords))),
+                genderCommand);
+
+        // parse age criteria
+        FindCommand ageCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + FindUtil.getFindCriteria(PREFIX_AGE, ageKeywords));
+        assertEquals(new FindCommand(new PredicateGroup(new AgeContainsKeywordsPredicate(ageKeywords))),
+                ageCommand);
+
+        // parse study groups criteria
+        FindCommand studyGroupsCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + FindUtil.getFindCriteria(PREFIX_TAG, generalKeywords));
+        assertEquals(new FindCommand(new PredicateGroup(
+                new StudyGroupsContainKeywordsPredicate(generalKeywords))),
+                studyGroupsCommand);
+
+        // parse details criteria
+        FindCommand detailsCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " "
+                        + FindUtil.getFindCriteria(PREFIX_DETAIL, generalKeywords));
+        assertEquals(new FindCommand(new PredicateGroup(new DetailsContainsKeywordsPredicate(generalKeywords))),
+                detailsCommand);
+
+        // parse multiple mixed criteria
+        FindCommand mixedCriteriaCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + FindUtil.getFindCriteria(PREFIX_NAME, generalKeywords)
+                        + " " + FindUtil.getFindCriteria(PREFIX_EMAIL, generalKeywords)
+                        + " " + FindUtil.getFindCriteria(PREFIX_GENDER, genderKeywords)
+                        + " " + FindUtil.getFindCriteria(PREFIX_AGE, ageKeywords)
+                        + " " + FindUtil.getFindCriteria(PREFIX_TAG, generalKeywords)
+                        + " " + FindUtil.getFindCriteria(PREFIX_DETAIL, generalKeywords));
+        PredicateGroup expectedPredicateGroup = new PredicateGroup(
+                new NameContainsKeywordsPredicate(generalKeywords),
+                new EmailContainsKeywordsPredicate(generalKeywords),
+                new GenderMatchesKeywordsPredicate(genderKeywords),
+                new AgeContainsKeywordsPredicate(ageKeywords),
+                new StudyGroupsContainKeywordsPredicate(generalKeywords),
+                new DetailsContainsKeywordsPredicate(generalKeywords));
+        assertEquals(new FindCommand(expectedPredicateGroup), mixedCriteriaCommand);
     }
 
     @Test
@@ -90,12 +160,14 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), () ->
+                parser.parseCommand(""));
     }
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
+                parser.parseCommand("unknownCommand"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -11,8 +11,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class CommandParserTestUtil {
 
     /**
-     * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created
-     * equals to {@code expectedCommand}.
+     * Asserts that the parsing of {@code userInput} by {@code parser} is successful
+     * and the command created equals to {@code expectedCommand}.
      */
     public static void assertParseSuccess(Parser<? extends Command> parser, String userInput,
             Command expectedCommand) {
@@ -25,8 +25,8 @@ public class CommandParserTestUtil {
     }
 
     /**
-     * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
-     * equals to {@code expectedMessage}.
+     * Asserts that the parsing of {@code userInput} by {@code parser} is
+     * unsuccessful and the error message equals to {@code expectedMessage}.
      */
     public static void assertParseFailure(Parser<? extends Command> parser, String userInput, String expectedMessage) {
         try {

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -9,7 +10,8 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.PredicateGroup;
 
 public class FindCommandParserTest {
 
@@ -23,12 +25,16 @@ public class FindCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        FindCommand expectedFindCommand = new FindCommand(
+                new PredicateGroup(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"))));
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " " + PREFIX_NAME + " \n Alice \n \t Bob  \t", expectedFindCommand);
     }
 
+    @Test
+    public void parse_nonemptyInvalidArg_throwsParseException() {
+        assertParseFailure(parser, "a", FindCommand.MESSAGE_NO_CRITERIA);
+    }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {

--- a/src/test/java/seedu/address/model/person/predicates/AgeContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/AgeContainsKeywordsPredicateTest.java
@@ -1,0 +1,74 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class AgeContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("11");
+        List<String> secondPredicateKeywordList = Arrays.asList("11", "12");
+
+        AgeContainsKeywordsPredicate firstPredicate = new AgeContainsKeywordsPredicate(firstPredicateKeywordList);
+        AgeContainsKeywordsPredicate secondPredicate = new AgeContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        AgeContainsKeywordsPredicate firstPredicateCopy = new AgeContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_ageContainsKeywords_returnsTrue() {
+        // One keyword
+        AgeContainsKeywordsPredicate predicate = new AgeContainsKeywordsPredicate(
+                Collections.singletonList("11"));
+        assertTrue(predicate.test(new PersonBuilder().withAge("11").build()));
+
+        // Only one matching keyword
+        predicate = new AgeContainsKeywordsPredicate(Arrays.asList("11", "12"));
+        assertTrue(predicate.test(new PersonBuilder().withAge("11").build()));
+    }
+
+    @Test
+    public void test_ageDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        AgeContainsKeywordsPredicate predicate = new AgeContainsKeywordsPredicate(
+                Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withAge("11").build()));
+
+        // Non-matching keyword
+        predicate = new AgeContainsKeywordsPredicate(Arrays.asList("12", "13"));
+        assertFalse(predicate.test(new PersonBuilder().withAge("11").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        AgeContainsKeywordsPredicate predicate = new AgeContainsKeywordsPredicate(keywords);
+
+        String expected = AgeContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/DetailsContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/DetailsContainsKeywordsPredicateTest.java
@@ -1,0 +1,84 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class DetailsContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        DetailsContainsKeywordsPredicate firstPredicate = new DetailsContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        DetailsContainsKeywordsPredicate secondPredicate = new DetailsContainsKeywordsPredicate(
+                secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        DetailsContainsKeywordsPredicate firstPredicateCopy = new DetailsContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_detailsContainsKeywords_returnsTrue() {
+        // One keyword
+        DetailsContainsKeywordsPredicate predicate = new DetailsContainsKeywordsPredicate(
+                Collections.singletonList("details"));
+        assertTrue(predicate.test(new PersonBuilder().withDetail("Sample details for this person").build()));
+
+        // Multiple keywords
+        predicate = new DetailsContainsKeywordsPredicate(Arrays.asList("this", "details"));
+        assertTrue(predicate.test(new PersonBuilder().withDetail("Sample details for this person").build()));
+
+        // Only one matching keyword
+        predicate = new DetailsContainsKeywordsPredicate(Arrays.asList("this", "nonsense"));
+        assertTrue(predicate.test(new PersonBuilder().withDetail("Sample details for this person").build()));
+
+        // Mixed-case keywords
+        predicate = new DetailsContainsKeywordsPredicate(Arrays.asList("tHiS", "DEtaIlS"));
+        assertTrue(predicate.test(new PersonBuilder().withDetail("Sample details for this person").build()));
+    }
+
+    @Test
+    public void test_detailsDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        DetailsContainsKeywordsPredicate predicate = new DetailsContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withDetail("Sample details for this person").build()));
+
+        // Non-matching keyword
+        predicate = new DetailsContainsKeywordsPredicate(Arrays.asList("detail"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        DetailsContainsKeywordsPredicate predicate = new DetailsContainsKeywordsPredicate(keywords);
+
+        String expected = DetailsContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/EmailContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/EmailContainsKeywordsPredicateTest.java
@@ -1,0 +1,86 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class EmailContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        EmailContainsKeywordsPredicate firstPredicate = new EmailContainsKeywordsPredicate(firstPredicateKeywordList);
+        EmailContainsKeywordsPredicate secondPredicate = new EmailContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        EmailContainsKeywordsPredicate firstPredicateCopy = new EmailContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_emailContainsKeywords_returnsTrue() {
+        // One keyword
+        EmailContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate(
+                Collections.singletonList("alice"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("alice@wonderland.com").build()));
+
+        // Multiple keywords
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("alice", "wonderland"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("alice@wonderland.com").build()));
+
+        // Only one matching keyword
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("wonderland", "oz"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("alice@wonderland.com").build()));
+
+        // Mixed-case keywords
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("aLIce", "WoNDeRlaNd"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("alice@wonderland.com").build()));
+    }
+
+    @Test
+    public void test_emailDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        EmailContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withEmail("alice@wonderland.com").build()));
+
+        // Non-matching keyword
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("Carol"));
+        assertFalse(predicate.test(new PersonBuilder().withEmail("alice@wonderland.com").build()));
+
+        // Keywords match name, but does not match email
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("12345", "Pauline", "gmail"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice Pauline").withEmail("alice@email.com").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        EmailContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate(keywords);
+
+        String expected = EmailContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/GenderMatchesKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/GenderMatchesKeywordsPredicateTest.java
@@ -1,0 +1,79 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class GenderMatchesKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        GenderMatchesKeywordsPredicate firstPredicate = new GenderMatchesKeywordsPredicate(firstPredicateKeywordList);
+        GenderMatchesKeywordsPredicate secondPredicate = new GenderMatchesKeywordsPredicate(
+                secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        GenderMatchesKeywordsPredicate firstPredicateCopy = new GenderMatchesKeywordsPredicate(
+                firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_emailContainsKeywords_returnsTrue() {
+        // One keyword
+        GenderMatchesKeywordsPredicate predicate = new GenderMatchesKeywordsPredicate(
+                Collections.singletonList("m"));
+        assertTrue(predicate.test(new PersonBuilder().withGender("M").build()));
+
+        // Multiple keywords
+        predicate = new GenderMatchesKeywordsPredicate(Arrays.asList("m", "M"));
+        assertTrue(predicate.test(new PersonBuilder().withGender("M").build()));
+
+        // Only one matching keyword
+        predicate = new GenderMatchesKeywordsPredicate(Arrays.asList("m", "F"));
+        assertTrue(predicate.test(new PersonBuilder().withGender("M").build()));
+    }
+
+    @Test
+    public void test_genderDoesNotMatchKeywords_returnsFalse() {
+        // Zero keywords
+        GenderMatchesKeywordsPredicate predicate = new GenderMatchesKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withGender("M").build()));
+
+        // Non-matching keyword
+        predicate = new GenderMatchesKeywordsPredicate(Arrays.asList("f"));
+        assertFalse(predicate.test(new PersonBuilder().withGender("M").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        GenderMatchesKeywordsPredicate predicate = new GenderMatchesKeywordsPredicate(keywords);
+
+        String expected = GenderMatchesKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicateTest.java
@@ -1,4 +1,4 @@
-package seedu.address.model.person;
+package seedu.address.model.person.predicates;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/seedu/address/model/person/predicates/PredicateGroupTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/PredicateGroupTest.java
@@ -1,0 +1,133 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+public class PredicateGroupTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
+
+        PredicateGroup firstPredicateGroup = new PredicateGroup(firstPredicate);
+        PredicateGroup secondPredicateGroup = new PredicateGroup(
+                new NameContainsKeywordsPredicate(secondPredicateKeywordList));
+
+        // same object -> returns true
+        assertTrue(firstPredicateGroup.equals(firstPredicateGroup));
+
+        // same values -> returns true
+        PredicateGroup firstPredicateGroupCopy = new PredicateGroup(firstPredicate);
+        assertTrue(firstPredicateGroup.equals(firstPredicateGroupCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicateGroup.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicateGroup.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicateGroup.equals(secondPredicateGroup));
+    }
+
+    @Test
+    public void add() {
+        List<String> keywords = Arrays.asList("keyword1", "keyword2");
+        NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(keywords);
+        EmailContainsKeywordsPredicate emailPredicate = new EmailContainsKeywordsPredicate(keywords);
+        GenderMatchesKeywordsPredicate genderPredicate = new GenderMatchesKeywordsPredicate(keywords);
+        AgeContainsKeywordsPredicate agePredicate = new AgeContainsKeywordsPredicate(keywords);
+        DetailsContainsKeywordsPredicate detailsPredicate = new DetailsContainsKeywordsPredicate(keywords);
+        StudyGroupsContainKeywordsPredicate studyGroupsPredicate = new StudyGroupsContainKeywordsPredicate(keywords);
+
+        PredicateGroup expectedPredicateGroup = new PredicateGroup(namePredicate, emailPredicate, genderPredicate,
+                agePredicate, detailsPredicate, studyGroupsPredicate);
+
+        PredicateGroup predicateGroup = new PredicateGroup();
+        predicateGroup.add(namePredicate);
+        predicateGroup.add(emailPredicate);
+        predicateGroup.add(genderPredicate);
+        predicateGroup.add(agePredicate);
+        predicateGroup.add(detailsPredicate);
+        predicateGroup.add(studyGroupsPredicate);
+        assertEquals(expectedPredicateGroup, predicateGroup);
+    }
+
+    @Test
+    public void test_personPassAllPredicate_returnsTrue() {
+        NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(
+                Arrays.asList("Kingsleigh", "Burton", "Lewis"));
+        EmailContainsKeywordsPredicate emailPredicate = new EmailContainsKeywordsPredicate(
+                Collections.singletonList("wonderland"));
+        GenderMatchesKeywordsPredicate genderPredicate = new GenderMatchesKeywordsPredicate(
+                Collections.singletonList("F"));
+        AgeContainsKeywordsPredicate agePredicate = new AgeContainsKeywordsPredicate(
+                Arrays.asList("20", "21", "22", "23"));
+        DetailsContainsKeywordsPredicate detailsPredicate = new DetailsContainsKeywordsPredicate(
+                Arrays.asList("wizard", "looking", "yellow"));
+        StudyGroupsContainKeywordsPredicate studyGroupsPredicate = new StudyGroupsContainKeywordsPredicate(
+                Arrays.asList("H1", "G3", "G4"));
+
+        Person person = new PersonBuilder().withName("Alice Kingsleigh").withEmail("alice@wonderland.com")
+                .withGender("F").withAge("22").withDetail("Went through the Looking Glass")
+                .withStudyGroups("H1", "H2", "G1").build();
+        PredicateGroup predicateGroup = new PredicateGroup(namePredicate, emailPredicate, genderPredicate,
+                agePredicate, detailsPredicate, studyGroupsPredicate);
+
+        assertTrue(predicateGroup.test(person));
+    }
+
+    @Test
+    public void test_personDoesNotPassAllPredicate_returnsFalse() {
+        NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(
+                Arrays.asList("Kingsleigh", "Burton", "Lewis"));
+        EmailContainsKeywordsPredicate emailPredicate = new EmailContainsKeywordsPredicate(
+                Collections.singletonList("wonderland"));
+        GenderMatchesKeywordsPredicate genderPredicate = new GenderMatchesKeywordsPredicate(
+                Collections.singletonList("M"));
+        AgeContainsKeywordsPredicate agePredicate = new AgeContainsKeywordsPredicate(
+                Arrays.asList("20", "21", "22", "23"));
+        DetailsContainsKeywordsPredicate detailsPredicate = new DetailsContainsKeywordsPredicate(
+                Arrays.asList("wizard", "looking", "yellow"));
+        StudyGroupsContainKeywordsPredicate studyGroupsPredicate = new StudyGroupsContainKeywordsPredicate(
+                Arrays.asList("H1", "G3", "G4"));
+
+        // Fail all predicates
+        Person person = new PersonBuilder().withName("Dorothy Gale").withEmail("dorothy@land.oz")
+                .withGender("F").withAge("18").withDetail("Up the tornado")
+                .withStudyGroups("O1", "O2", "O3").build();
+        PredicateGroup predicateGroup = new PredicateGroup(namePredicate, emailPredicate, genderPredicate,
+                agePredicate, detailsPredicate, studyGroupsPredicate);
+
+        assertFalse(predicateGroup.test(person));
+
+        // Fail one predicate (detail predicate will fail)
+        person = new PersonBuilder().withName("Alice Kingsleigh").withEmail("alice@wonderland.com")
+                .withGender("F").withAge("22").withDetail("Went through the unlooking Glass")
+                .withStudyGroups("H1", "H2", "G1").build();
+
+        assertFalse(predicateGroup.test(person));
+    }
+
+    @Test
+    public void toStringMethod() {
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(
+                Arrays.asList("keyword1", "keyword2"));
+        PredicateGroup predicateGroup = new PredicateGroup(predicate);
+
+        String expected = PredicateGroup.class.getCanonicalName() + "{predicates=[" + predicate + "]}";
+        assertEquals(expected, predicateGroup.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/StudyGroupsContainKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/StudyGroupsContainKeywordsPredicateTest.java
@@ -1,0 +1,85 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class StudyGroupsContainKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        StudyGroupsContainKeywordsPredicate firstPredicate = new StudyGroupsContainKeywordsPredicate(
+                firstPredicateKeywordList);
+        StudyGroupsContainKeywordsPredicate secondPredicate = new StudyGroupsContainKeywordsPredicate(
+                secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        StudyGroupsContainKeywordsPredicate firstPredicateCopy = new StudyGroupsContainKeywordsPredicate(
+                firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_studyGroupsContainKeywords_returnsTrue() {
+        // One keyword
+        StudyGroupsContainKeywordsPredicate predicate = new StudyGroupsContainKeywordsPredicate(
+                Collections.singletonList("Group1"));
+        assertTrue(predicate.test(new PersonBuilder().withStudyGroups("Group1", "Group2").build()));
+
+        // Multiple keywords
+        predicate = new StudyGroupsContainKeywordsPredicate(Arrays.asList("Group1", "Group2"));
+        assertTrue(predicate.test(new PersonBuilder().withStudyGroups("Group1", "Group2").build()));
+
+        // Only one matching keyword
+        predicate = new StudyGroupsContainKeywordsPredicate(Arrays.asList("Group1", "NotGroup"));
+        assertTrue(predicate.test(new PersonBuilder().withStudyGroups("Group1", "Group2").build()));
+
+        // Mixed-case keywords
+        predicate = new StudyGroupsContainKeywordsPredicate(Arrays.asList("gRoUP1", "GRouP2"));
+        assertTrue(predicate.test(new PersonBuilder().withStudyGroups("Group1", "Group2").build()));
+    }
+
+    @Test
+    public void test_studyGroupsDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        StudyGroupsContainKeywordsPredicate predicate = new StudyGroupsContainKeywordsPredicate(
+                Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withStudyGroups("Group1", "Group2").build()));
+
+        // Non-matching keyword
+        predicate = new StudyGroupsContainKeywordsPredicate(Arrays.asList("Group3", "Group4"));
+        assertFalse(predicate.test(new PersonBuilder().withStudyGroups("Group1", "Group2").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        StudyGroupsContainKeywordsPredicate predicate = new StudyGroupsContainKeywordsPredicate(keywords);
+
+        String expected = StudyGroupsContainKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/testutil/FindUtil.java
+++ b/src/test/java/seedu/address/testutil/FindUtil.java
@@ -1,0 +1,19 @@
+package seedu.address.testutil;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import seedu.address.logic.parser.Prefix;
+
+/**
+ * A utility class for Find command.
+ */
+public class FindUtil {
+    /**
+     * Returns a criteria for find command using provided {@code Prefix} and
+     * keywords.
+     */
+    public static String getFindCriteria(Prefix prefix, List<String> keywords) {
+        return prefix + keywords.stream().collect(Collectors.joining(" "));
+    }
+}


### PR DESCRIPTION
Expand Find command functionality to find by any field (in Person).

Find command format: `find [n/NAME ...] [e/EMAIL ...] [g/GENDER ...] [d/DETAILS ...] [t/STUDYGROUPS ...]`
Eg. `find n/alice bob e/nus.edu.sg g/f a/22 23 24 t/G1 G7 G8`

Given multiple criteria, the Find command will retrieve person(s) whose field(s) satisfies **all criteria provided**, where each criteria consist of one and only one field.
That is, `n/alice bob` is one criterion that specifies that the person's name must contain either "alive" or "bob"