### PR TITLE
Enable assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,8 @@ shadowJar {
     archiveFileName = 'addressbook.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = 'researchroster.jar'
 }
 
 run {


### PR DESCRIPTION
Fixes #82 

Updated `build.gradle` to enable assertions in the team repo.