### PR TITLE
Alpha Version - Assign study groups randomly

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -1,0 +1,170 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Age;
+import seedu.address.model.person.Detail;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Gender;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.StudyGroupTag;
+
+/**
+ * Assigns the current listed participants into study groups
+ */
+public class AssignCommand extends Command {
+
+    public static final String COMMAND_WORD = "assign";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Assigns persons in the displayed person list randomly to the distinct input study group(s).\n"
+            + "Parameters: "
+            + "STUDY_GROUP_1 [...]\n"
+            + "Example: " + COMMAND_WORD + " P90-Placebo P90-Experimental";
+
+    public static final String MESSAGE_SUCCESS = "Assigned participants successfully!";
+    public static final String MESSAGE_DUPLICATE_STUDYGROUP = "There are duplicate study groups in your input!";
+    public static final String MESSAGE_EXISTING_STUDYGROUP = "This study group has already been assigned to one "
+            + " or more participant(s) in this list!";
+
+    private final List<AssignStudyGroupTagDescriptor> possibleAssignment;
+
+    /**
+     * Creates an AssignCommand to add the list of {@code AssignStudyGroupTagDescriptor}
+     */
+    public AssignCommand(List<AssignStudyGroupTagDescriptor> assignStudyGroupTagDescriptors) {
+        requireNonNull(assignStudyGroupTagDescriptors);
+        possibleAssignment = assignStudyGroupTagDescriptors;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        List<StudyGroupTag> existingStudyGroups = model.getFilteredPersonList().stream()
+                .flatMap(person -> person.getStudyGroupTags().stream())
+                .distinct()
+                .collect(Collectors.toList());
+
+        for (AssignStudyGroupTagDescriptor d : possibleAssignment) {
+            if (existingStudyGroups.contains(d.getStudyGroupTag())) {
+                throw new CommandException(MESSAGE_EXISTING_STUDYGROUP);
+            }
+        }
+
+        model.getFilteredPersonList().stream()
+                .forEach(person -> {
+                    int choice = new Random().nextInt(possibleAssignment.size());
+                    model.setPerson(person,
+                            createAssignedPerson(person, possibleAssignment.get(choice)));
+                });
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AssignCommand)) {
+            return false;
+        }
+
+        AssignCommand otherAssignCommand = (AssignCommand) other;
+        return possibleAssignment.equals(otherAssignCommand.possibleAssignment);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("possible assignments", possibleAssignment)
+                .toString();
+    }
+
+    /**
+     * Creates and returns a {@code Person} with the details of {@code personToEdit} edited with
+     * {@code editPersonDescriptor}.
+     */
+    private static Person createAssignedPerson(Person personToEdit,
+            AssignStudyGroupTagDescriptor assignStudyGroupTagDescriptor) {
+        assert personToEdit != null;
+        assert assignStudyGroupTagDescriptor != null;
+
+        Name name = personToEdit.getName();
+        Email email = personToEdit.getEmail();
+        Gender gender = personToEdit.getGender();
+        Age age = personToEdit.getAge();
+        Detail detail = personToEdit.getDetail();
+
+        Set<StudyGroupTag> updatedStudyGroups = new HashSet<>();
+        updatedStudyGroups.addAll(personToEdit.getStudyGroupTags());
+        updatedStudyGroups.add(assignStudyGroupTagDescriptor.getStudyGroupTag());
+
+        return new Person(name, email, gender, age, detail, updatedStudyGroups);
+    }
+
+    /**
+     * Stores the possible study groups a person can be assigned to.
+     */
+    public static class AssignStudyGroupTagDescriptor {
+        private StudyGroupTag toAssign;
+
+        public AssignStudyGroupTagDescriptor() {
+        }
+
+        /**
+         * Copy constructor.
+         */
+        public AssignStudyGroupTagDescriptor(AssignStudyGroupTagDescriptor toCopy) {
+            assert toCopy != null;
+            setStudyGroupTag(toCopy.toAssign);
+        }
+
+        /**
+         * Sets this object's {@code toAssign} to {@code studyGroupTag}.
+         */
+        public void setStudyGroupTag(StudyGroupTag studyGroupTag) {
+            this.toAssign = studyGroupTag;
+        }
+
+        public StudyGroupTag getStudyGroupTag() {
+            return toAssign;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof AssignStudyGroupTagDescriptor)) {
+                return false;
+            }
+
+            AssignStudyGroupTagDescriptor otherAssignStudyGroupTagDescriptor = (AssignStudyGroupTagDescriptor) other;
+            return Objects.equals(toAssign, otherAssignStudyGroupTagDescriptor.toAssign);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .add("study groups to assign", toAssign)
+                    .toString();
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AssignCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -74,6 +75,9 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case AssignCommand.COMMAND_WORD:
+            return new AssignCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/AssignCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignCommandParser.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import seedu.address.logic.commands.AssignCommand;
+import seedu.address.logic.commands.AssignCommand.AssignStudyGroupTagDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.StudyGroupTag;
+
+/**
+ * Parses input arguments and creates a new AssignCommand object
+ */
+public class AssignCommandParser implements Parser<AssignCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AssignCommand and returns an AssignCommand
+     * object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AssignCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignCommand.MESSAGE_USAGE));
+        }
+
+        String[] studyGroups = args.trim().split("\\s+");
+
+        if (Arrays.stream(studyGroups).distinct().count() < studyGroups.length) {
+            throw new ParseException(AssignCommand.MESSAGE_DUPLICATE_STUDYGROUP);
+        }
+
+        List<AssignStudyGroupTagDescriptor> assignStudyGroupTagDescriptors;
+        try {
+            assignStudyGroupTagDescriptors = Arrays.stream(args.trim().split("\\s+"))
+                    .map(name -> {
+                        try {
+                            AssignStudyGroupTagDescriptor assignStudyGroupTagDescriptor =
+                                    new AssignStudyGroupTagDescriptor();
+                            assignStudyGroupTagDescriptor.setStudyGroupTag(ParserUtil.parseStudyGroup(name));
+                            return assignStudyGroupTagDescriptor;
+                        } catch (ParseException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .collect(Collectors.toList());
+        } catch (RuntimeException e) {
+            throw new ParseException(StudyGroupTag.MESSAGE_CONSTRAINTS, e);
+        }
+
+        return new AssignCommand(assignStudyGroupTagDescriptors);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AssignCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignCommandParser.java
@@ -37,11 +37,11 @@ public class AssignCommandParser implements Parser<AssignCommand> {
 
         List<AssignStudyGroupTagDescriptor> assignStudyGroupTagDescriptors;
         try {
-            assignStudyGroupTagDescriptors = Arrays.stream(args.trim().split("\\s+"))
+            assignStudyGroupTagDescriptors = Arrays.stream(studyGroups)
                     .map(name -> {
                         try {
                             AssignStudyGroupTagDescriptor assignStudyGroupTagDescriptor =
-                                    new AssignStudyGroupTagDescriptor();
+                                  new AssignStudyGroupTagDescriptor();
                             assignStudyGroupTagDescriptor.setStudyGroupTag(ParserUtil.parseStudyGroup(name));
                             return assignStudyGroupTagDescriptor;
                         } catch (ParseException e) {

--- a/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
@@ -1,0 +1,111 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_3A;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_3B;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDY_GROUP_TAG_1A;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_UNUSED_STUDY_GROUP_TAG_3A;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_UNUSED_STUDY_GROUP_TAG_3B;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AssignCommand.AssignStudyGroupTagDescriptor;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.tag.StudyGroupTag;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for AssignCommand.
+ */
+public class AssignCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model controlModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_twoStudyGroupSpecifiedUnfilteredList_success() {
+        AssignStudyGroupTagDescriptor descriptor3A = new AssignStudyGroupTagDescriptor();
+        descriptor3A.setStudyGroupTag(new StudyGroupTag(VALID_UNUSED_STUDY_GROUP_TAG_3A));
+        AssignStudyGroupTagDescriptor descriptor3B = new AssignStudyGroupTagDescriptor();
+        descriptor3B.setStudyGroupTag(new StudyGroupTag(VALID_UNUSED_STUDY_GROUP_TAG_3B));
+
+        List<AssignStudyGroupTagDescriptor> descriptors = Arrays.asList(descriptor3A, descriptor3B);
+        AssignCommand assignCommand = new AssignCommand(descriptors);
+
+        String expectedMessage = AssignCommand.MESSAGE_SUCCESS;
+
+        assertCommandSuccess(assignCommand, model, expectedMessage, model);
+
+        for (int i = 0; i < model.getFilteredPersonList().size(); i++) {
+            assertNotEquals(model.getFilteredPersonList().get(i), controlModel.getFilteredPersonList().get(i));
+
+        }
+    }
+
+    @Test
+    public void execute_existingStudyGroupUnfilteredList_failure() {
+        AssignStudyGroupTagDescriptor descriptor1A = new AssignStudyGroupTagDescriptor();
+        descriptor1A.setStudyGroupTag(new StudyGroupTag(VALID_STUDY_GROUP_TAG_1A));
+
+        List<AssignStudyGroupTagDescriptor> descriptors = Collections.singletonList(descriptor1A);
+        AssignCommand assignCommand = new AssignCommand(descriptors);
+
+        assertCommandFailure(assignCommand, model, AssignCommand.MESSAGE_EXISTING_STUDYGROUP);
+    }
+
+    @Test
+    public void execute_existingStudyGroupFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        AssignStudyGroupTagDescriptor descriptor1A = new AssignStudyGroupTagDescriptor();
+        descriptor1A.setStudyGroupTag(new StudyGroupTag(VALID_STUDY_GROUP_TAG_1A));
+
+        List<AssignStudyGroupTagDescriptor> descriptors = Collections.singletonList(descriptor1A);
+        AssignCommand assignCommand = new AssignCommand(descriptors);
+
+        assertCommandFailure(assignCommand, model, AssignCommand.MESSAGE_EXISTING_STUDYGROUP);
+    }
+
+    @Test
+    public void equals() {
+        final AssignCommand standardCommand = new AssignCommand(Collections.singletonList(DESC_3A));
+
+        // same values -> returns true
+        AssignStudyGroupTagDescriptor copyDescriptor = new AssignStudyGroupTagDescriptor(DESC_3A);
+        AssignCommand commandWithSameValues = new AssignCommand(Collections.singletonList(copyDescriptor));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new AssignCommand(Collections.singletonList(DESC_3B))));
+    }
+
+    @Test
+    public void toStringMethod() {
+        AssignStudyGroupTagDescriptor assignStudyGroupTagDescriptor = new AssignStudyGroupTagDescriptor(DESC_3A);
+        AssignCommand assignCommand = new AssignCommand(Collections.singletonList(assignStudyGroupTagDescriptor));
+        String expected = AssignCommand.class.getCanonicalName() + "{possible assignments=[" + DESC_3A + "]}";
+        assertEquals(expected, assignCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
@@ -21,10 +21,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AssignCommand.AssignStudyGroupTagDescriptor;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
 import seedu.address.model.tag.StudyGroupTag;
+import seedu.address.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for AssignCommand.
@@ -74,6 +77,51 @@ public class AssignCommandTest {
             assertNotEquals(model.getFilteredPersonList().get(i), controlModel.getFilteredPersonList().get(i));
 
         }
+    }
+
+    @Test
+    public void execute_oneStudyGroupSpecifiedUnfilteredList_success() {
+        AssignStudyGroupTagDescriptor descriptor3A = new AssignStudyGroupTagDescriptor();
+        descriptor3A.setStudyGroupTag(new StudyGroupTag(VALID_UNUSED_STUDY_GROUP_TAG_3A));
+
+        List<AssignStudyGroupTagDescriptor> descriptors = Collections.singletonList(descriptor3A);
+        AssignCommand assignCommand = new AssignCommand(descriptors);
+
+        String expectedMessage = AssignCommand.MESSAGE_SUCCESS;
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        for (Person p : expectedModel.getFilteredPersonList()) {
+            PersonBuilder personInList = new PersonBuilder(p);
+            Person editedPerson = personInList.withAppendStudyGroupTags(VALID_UNUSED_STUDY_GROUP_TAG_3A).build();
+            expectedModel.setPerson(p, editedPerson);
+        }
+
+        assertCommandSuccess(assignCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_oneStudyGroupSpecifiedFilteredList_success() {
+        showPersonWithStudyGroupTag(model, VALID_STUDY_GROUP_TAG_1A);
+
+        AssignStudyGroupTagDescriptor descriptor3A = new AssignStudyGroupTagDescriptor();
+        descriptor3A.setStudyGroupTag(new StudyGroupTag(VALID_UNUSED_STUDY_GROUP_TAG_3A));
+
+        List<AssignStudyGroupTagDescriptor> descriptors = Collections.singletonList(descriptor3A);
+        AssignCommand assignCommand = new AssignCommand(descriptors);
+
+        String expectedMessage = AssignCommand.MESSAGE_SUCCESS;
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        showPersonWithStudyGroupTag(expectedModel, VALID_STUDY_GROUP_TAG_1A);
+
+        for (Person p : expectedModel.getFilteredPersonList()) {
+            PersonBuilder personInList = new PersonBuilder(p);
+            Person editedPerson = personInList.withAppendStudyGroupTags(VALID_UNUSED_STUDY_GROUP_TAG_3A).build();
+            expectedModel.setPerson(p, editedPerson);
+        }
+
+        assertCommandSuccess(assignCommand, model, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
@@ -11,8 +11,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_UNUSED_STUDY_GR
 import static seedu.address.logic.commands.CommandTestUtil.VALID_UNUSED_STUDY_GROUP_TAG_3B;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonWithStudyGroupTag;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -56,6 +55,28 @@ public class AssignCommandTest {
     }
 
     @Test
+    public void execute_twoStudyGroupSpecifiedFilteredList_success() {
+        showPersonWithStudyGroupTag(model, VALID_STUDY_GROUP_TAG_1A);
+
+        AssignStudyGroupTagDescriptor descriptor3A = new AssignStudyGroupTagDescriptor();
+        descriptor3A.setStudyGroupTag(new StudyGroupTag(VALID_UNUSED_STUDY_GROUP_TAG_3A));
+        AssignStudyGroupTagDescriptor descriptor3B = new AssignStudyGroupTagDescriptor();
+        descriptor3B.setStudyGroupTag(new StudyGroupTag(VALID_UNUSED_STUDY_GROUP_TAG_3B));
+
+        List<AssignStudyGroupTagDescriptor> descriptors = Arrays.asList(descriptor3A, descriptor3B);
+        AssignCommand assignCommand = new AssignCommand(descriptors);
+
+        String expectedMessage = AssignCommand.MESSAGE_SUCCESS;
+
+        assertCommandSuccess(assignCommand, model, expectedMessage, model);
+
+        for (int i = 0; i < model.getFilteredPersonList().size(); i++) {
+            assertNotEquals(model.getFilteredPersonList().get(i), controlModel.getFilteredPersonList().get(i));
+
+        }
+    }
+
+    @Test
     public void execute_existingStudyGroupUnfilteredList_failure() {
         AssignStudyGroupTagDescriptor descriptor1A = new AssignStudyGroupTagDescriptor();
         descriptor1A.setStudyGroupTag(new StudyGroupTag(VALID_STUDY_GROUP_TAG_1A));
@@ -68,7 +89,7 @@ public class AssignCommandTest {
 
     @Test
     public void execute_existingStudyGroupFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonWithStudyGroupTag(model, VALID_STUDY_GROUP_TAG_1A);
 
         AssignStudyGroupTagDescriptor descriptor1A = new AssignStudyGroupTagDescriptor();
         descriptor1A.setStudyGroupTag(new StudyGroupTag(VALID_STUDY_GROUP_TAG_1A));

--- a/src/test/java/seedu/address/logic/commands/AssignStudyGroupTagDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignStudyGroupTagDescriptorTest.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_3A;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_3B;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDY_GROUP_TAG_2B;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AssignCommand.AssignStudyGroupTagDescriptor;
+import seedu.address.testutil.AssignStudyGroupTagDescriptorBuilder;
+
+public class AssignStudyGroupTagDescriptorTest {
+    @Test
+    public void equals() {
+        // same values -> returns true
+        AssignStudyGroupTagDescriptor descriptorWithSameValues = new AssignStudyGroupTagDescriptor(DESC_3A);
+        assertTrue(DESC_3A.equals(descriptorWithSameValues));
+
+        // same object -> returns true
+        assertTrue(DESC_3A.equals(DESC_3A));
+
+        // null -> returns false
+        assertFalse(DESC_3A.equals(null));
+
+        // different types -> returns false
+        assertFalse(DESC_3A.equals(5));
+
+        // different values -> returns false
+        assertFalse(DESC_3A.equals(DESC_3B));
+
+        // different name -> returns false
+        AssignStudyGroupTagDescriptor edited1A = new AssignStudyGroupTagDescriptorBuilder(DESC_3A)
+                .withStudyGroupTag(VALID_STUDY_GROUP_TAG_2B).build();
+        assertFalse(DESC_3A.equals(edited1A));
+    }
+
+    @Test
+    public void toStringMethod() {
+        AssignStudyGroupTagDescriptor assignStudyGroupTagDescriptor = new AssignStudyGroupTagDescriptor();
+        String expected = AssignStudyGroupTagDescriptor.class.getCanonicalName() + "{study groups to assign="
+                + assignStudyGroupTagDescriptor.getStudyGroupTag() + "}";
+        assertEquals(expected, assignStudyGroupTagDescriptor.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -21,6 +21,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
+import seedu.address.testutil.AssignStudyGroupTagDescriptorBuilder;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 /**
@@ -40,6 +41,8 @@ public class CommandTestUtil {
     public static final String VALID_DETAIL_BOB = "To follow up";
     public static final String VALID_STUDY_GROUP_TAG_1A = "1A";
     public static final String VALID_STUDY_GROUP_TAG_2B = "2B";
+    public static final String VALID_UNUSED_STUDY_GROUP_TAG_3A = "3A";
+    public static final String VALID_UNUSED_STUDY_GROUP_TAG_3B = "3B";
     public static final String VALID_TAG_AMY = VALID_STUDY_GROUP_TAG_2B;
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
@@ -67,6 +70,8 @@ public class CommandTestUtil {
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
 
+    public static final AssignCommand.AssignStudyGroupTagDescriptor DESC_3A;
+    public static final AssignCommand.AssignStudyGroupTagDescriptor DESC_3B;
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
@@ -77,12 +82,15 @@ public class CommandTestUtil {
                 .withEmail(VALID_EMAIL_BOB).withGender(VALID_GENDER_BOB).withAge(VALID_AGE_BOB)
                 .withDetail(VALID_DETAIL_BOB).withStudyGroupTags(VALID_STUDY_GROUP_TAG_1A, VALID_STUDY_GROUP_TAG_2B)
                 .build();
+
+        DESC_3A = new AssignStudyGroupTagDescriptorBuilder().withStudyGroupTag(VALID_UNUSED_STUDY_GROUP_TAG_3A).build();
+
+        DESC_3B = new AssignStudyGroupTagDescriptorBuilder().withStudyGroupTag(VALID_UNUSED_STUDY_GROUP_TAG_3B).build();
     }
 
     /**
      * Executes the given {@code command}, confirms that <br>
-     * - the returned {@link CommandResult} matches {@code expectedCommandResult}
-     * <br>
+     * - the returned {@link CommandResult} matches {@code expectedCommandResult} <br>
      * - the {@code actualModel} matches {@code expectedModel}
      */
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
@@ -97,9 +105,8 @@ public class CommandTestUtil {
     }
 
     /**
-     * Convenience wrapper to
-     * {@link #assertCommandSuccess(Command, Model, CommandResult, Model)} that
-     * takes a string {@code expectedMessage}.
+     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)} that takes a string
+     * {@code expectedMessage}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
             Model expectedModel) {
@@ -111,8 +118,7 @@ public class CommandTestUtil {
      * Executes the given {@code command}, confirms that <br>
      * - a {@code CommandException} is thrown <br>
      * - the CommandException message matches {@code expectedMessage} <br>
-     * - the address book, filtered person list and selected person in
-     * {@code actualModel} remain unchanged
+     * - the address book, filtered person list and selected person in {@code actualModel} remain unchanged
      */
     public static void assertCommandFailure(Command command, Model actualModel, String expectedMessage) {
         // we are unable to defensively copy the model for comparison later, so we can
@@ -126,8 +132,8 @@ public class CommandTestUtil {
     }
 
     /**
-     * Updates {@code model}'s filtered list to show only the person at the given
-     * {@code targetIndex} in the {@code model}'s address book.
+     * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
+     * {@code model}'s address book.
      */
     public static void showPersonAtIndex(Model model, Index targetIndex) {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -13,6 +13,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -21,6 +22,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.StudyGroupsContainKeywordsPredicate;
 import seedu.address.testutil.AssignStudyGroupTagDescriptorBuilder;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
@@ -143,6 +145,20 @@ public class CommandTestUtil {
         model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredPersonList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the persons that are tagged with {@code studyGroupName} in the
+     * {@code model}'s address book.
+     */
+    public static void showPersonWithStudyGroupTag(Model model, String studyGroupName) {
+        StudyGroupsContainKeywordsPredicate studyGroupPredicate = new StudyGroupsContainKeywordsPredicate(
+                Collections.singletonList(studyGroupName));
+        model.updateFilteredPersonList(studyGroupPredicate);
+
+        for (Person p : model.getFilteredPersonList()) {
+            assertTrue(studyGroupPredicate.test(p));
+        }
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_3A;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_UNUSED_STUDY_GROUP_TAG_3A;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -14,11 +16,13 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AssignCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -165,6 +169,13 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_assign() throws Exception {
+        AssignCommand command = (AssignCommand) parser.parseCommand(
+                AssignCommand.COMMAND_WORD + " " + VALID_UNUSED_STUDY_GROUP_TAG_3A);
+        assertEquals(new AssignCommand(Collections.singletonList(DESC_3A)), command);
+    }
+
+    @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), () ->
@@ -173,7 +184,6 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
-                parser.parseCommand("unknownCommand"));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AssignCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AssignCommandParserTest.java
@@ -24,7 +24,7 @@ public class AssignCommandParserTest {
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
+    public void parse_validArgs_returnsAssignCommand() {
         AssignStudyGroupTagDescriptor descriptor3A = new AssignStudyGroupTagDescriptor();
         descriptor3A.setStudyGroupTag(new StudyGroupTag(VALID_UNUSED_STUDY_GROUP_TAG_3A));
         AssignStudyGroupTagDescriptor descriptor3B = new AssignStudyGroupTagDescriptor();

--- a/src/test/java/seedu/address/logic/parser/AssignCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AssignCommandParserTest.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_UNUSED_STUDY_GROUP_TAG_3A;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_UNUSED_STUDY_GROUP_TAG_3B;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AssignCommand;
+import seedu.address.logic.commands.AssignCommand.AssignStudyGroupTagDescriptor;
+import seedu.address.model.tag.StudyGroupTag;
+
+public class AssignCommandParserTest {
+    private AssignCommandParser parser = new AssignCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        AssignStudyGroupTagDescriptor descriptor3A = new AssignStudyGroupTagDescriptor();
+        descriptor3A.setStudyGroupTag(new StudyGroupTag(VALID_UNUSED_STUDY_GROUP_TAG_3A));
+        AssignStudyGroupTagDescriptor descriptor3B = new AssignStudyGroupTagDescriptor();
+        descriptor3B.setStudyGroupTag(new StudyGroupTag(VALID_UNUSED_STUDY_GROUP_TAG_3B));
+
+        List<AssignStudyGroupTagDescriptor> expectedDescriptors = Arrays.asList(descriptor3A, descriptor3B);
+        AssignCommand expectedAssignCommand = new AssignCommand(expectedDescriptors);
+
+        assertParseSuccess(parser, VALID_UNUSED_STUDY_GROUP_TAG_3A + " " + VALID_UNUSED_STUDY_GROUP_TAG_3B,
+                expectedAssignCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, VALID_UNUSED_STUDY_GROUP_TAG_3A + " \n \t  " + VALID_UNUSED_STUDY_GROUP_TAG_3B,
+                expectedAssignCommand);
+    }
+
+    @Test
+    public void parse_duplicateStudyGroups_failure() {
+        assertParseFailure(parser,
+                VALID_UNUSED_STUDY_GROUP_TAG_3A + " " + VALID_UNUSED_STUDY_GROUP_TAG_3A,
+                AssignCommand.MESSAGE_DUPLICATE_STUDYGROUP);
+    }
+
+    @Test
+    public void parse_nonemptyInvalidArg_throwsParseException() {
+        assertParseFailure(parser, "@", StudyGroupTag.MESSAGE_CONSTRAINTS);
+    }
+}

--- a/src/test/java/seedu/address/testutil/AssignStudyGroupTagDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/AssignStudyGroupTagDescriptorBuilder.java
@@ -1,0 +1,33 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.AssignCommand.AssignStudyGroupTagDescriptor;
+import seedu.address.model.tag.StudyGroupTag;
+
+/**
+ * A utility class to help with building EditPersonDescriptor objects.
+ */
+public class AssignStudyGroupTagDescriptorBuilder {
+
+    private AssignStudyGroupTagDescriptor descriptor;
+
+    public AssignStudyGroupTagDescriptorBuilder() {
+        descriptor = new AssignStudyGroupTagDescriptor();
+    }
+
+    public AssignStudyGroupTagDescriptorBuilder(AssignStudyGroupTagDescriptor descriptor) {
+        this.descriptor = new AssignStudyGroupTagDescriptor(descriptor);
+    }
+
+    /**
+     * Parses the {@code studyGroups} into a {@code Set<StudyGroupTag>} and set it to the {@code EditPersonDescriptor}
+     * that we are building.
+     */
+    public AssignStudyGroupTagDescriptorBuilder withStudyGroupTag(String studyGroup) {
+        descriptor.setStudyGroupTag(new StudyGroupTag(studyGroup));
+        return this;
+    }
+
+    public AssignStudyGroupTagDescriptor build() {
+        return descriptor;
+    }
+}

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -94,11 +94,20 @@ public class PersonBuilder {
     }
 
     /**
-     * Parses the {@code studyGroups} into a {@code Set<StudyGroupTag>} and set it
-     * to the {@code Person} that we are building.
+     * Parses the {@code studyGroups} into a {@code Set<StudyGroupTag>} and set it to the {@code Person} that we are
+     * building.
      */
     public PersonBuilder withStudyGroupTags(String... studyGroups) {
         this.studyGroupTags = SampleDataUtil.getStudyGroupTagSet(studyGroups);
+        return this;
+    }
+
+    /**
+     * Parses the {@code studyGroups} into a {@code Set<StudyGroupTag>} and add it to the {@code Person} that we are
+     * building's existing set of study group tags .
+     */
+    public PersonBuilder withAppendStudyGroupTags(String... studyGroups) {
+        this.studyGroupTags.addAll(SampleDataUtil.getStudyGroupTagSet(studyGroups));
         return this;
     }
 


### PR DESCRIPTION
Fixes #121 

The feature is implemented as the Assign command, with the `assign` command word. The Assign command takes in study group name(s) and randomly assigns the persons in the current displayed list to a study group.

## Assign command format:
`assign STUDY_GROUP_1 [STUDY_GROUP_2 ...]`
- Users can input one or more study groups
  - If only one study group, assign every person in current displayed list to that specified study group
  - Otherwise, randomly assign each person to a study group from the specified list
- No person in the current displayed list should be tagged with any input study group name
- Input study group names should not have duplicates

Eg. `assign Placebo Experimental`
![](https://github.com/user-attachments/assets/8b93ec20-6c08-48b1-b385-de65be9a6ad8)


_Note: Study groups will be fixed in a later PR to accept special characters such as dashes "`-`" to be more expressive. Refer to #124._
