### PR TITLE
StudyGroupTag - Expand constraint on study group names

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -28,7 +28,7 @@ public class AddCommand extends Command {
             + PREFIX_GENDER + "GENDER "
             + PREFIX_AGE + "AGE "
             + "[" + PREFIX_DETAIL + "DETAIL] "
-            + "[" + PREFIX_STUDY_GROUP_TAG + "STUDY_GROUP_TAG]..."
+            + "[" + PREFIX_STUDY_GROUP_TAG + "STUDY-GROUP-TAG]..."
             + "\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -50,7 +50,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_GENDER + "GENDER] "
             + "[" + PREFIX_AGE + "AGE] "
             + "[" + PREFIX_DETAIL + "DETAIL]"
-            + "[" + PREFIX_STUDY_GROUP_TAG + "STUDY_GROUP_TAG]...\n"
+            + "[" + PREFIX_STUDY_GROUP_TAG + "STUDY-GROUP-TAG]...\n"
             + "[" + PREFIX_REMOVE_TAG + "TAG_TO_REMOVE]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_EMAIL + "johndoe@example.com";
@@ -96,8 +96,8 @@ public class EditCommand extends Command {
     }
 
     /**
-     * Creates and returns a {@code Person} with the details of {@code personToEdit}
-     * edited with {@code editPersonDescriptor}.
+     * Creates and returns a {@code Person} with the details of {@code personToEdit} edited with
+     * {@code editPersonDescriptor}.
      */
     private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
         assert personToEdit != null;
@@ -142,8 +142,8 @@ public class EditCommand extends Command {
     }
 
     /**
-     * Stores the details to edit the person with. Each non-empty field value will
-     * replace the corresponding field value of the person.
+     * Stores the details to edit the person with. Each non-empty field value will replace the corresponding field value
+     * of the person.
      */
     public static class EditPersonDescriptor {
         private Name name;
@@ -220,8 +220,8 @@ public class EditCommand extends Command {
         }
 
         /**
-         * Sets this object's {@code studyGroupTags} to {@code studyGroupTags} . A defensive
-         * copy of {@code studyGroupTags} is used internally.
+         * Sets this object's {@code studyGroupTags} to {@code studyGroupTags} . A defensive copy of
+         * {@code studyGroupTags} is used internally.
          */
         public void setStudyGroupTags(Set<StudyGroupTag> studyGroupTags) {
             this.studyGroupTags = (studyGroupTags != null) ? new HashSet<>(studyGroupTags) : null;
@@ -229,8 +229,8 @@ public class EditCommand extends Command {
 
         /**
          * Returns an unmodifiable tag set of existing and added tags, which throws
-         * {@code UnsupportedOperationException} if modification is attempted. Returns
-         * {@code Optional#empty()} if {@code studyGroupTags} is null.
+         * {@code UnsupportedOperationException} if modification is attempted. Returns {@code Optional#empty()} if
+         * {@code studyGroupTags} is null.
          */
         public Optional<Set<StudyGroupTag>> getStudyGroupTags() {
             return (studyGroupTags != null)
@@ -239,16 +239,16 @@ public class EditCommand extends Command {
         }
 
         /**
-         * Sets this object's {@code tagsToRemove} to {@code tagsToRemove} . A defensive
-         * copy of {@code studyGroupTags} is used internally.
+         * Sets this object's {@code tagsToRemove} to {@code tagsToRemove} . A defensive copy of {@code studyGroupTags}
+         * is used internally.
          */
         public void setTagsToRemove(Set<StudyGroupTag> studyGroupTags) {
             this.tagsToRemove = (studyGroupTags != null) ? new HashSet<>(studyGroupTags) : null;
         }
+
         /**
-         * Returns an unmodifiable tag set to remove, which throws
-         * {@code UnsupportedOperationException} if modification is attempted. Returns
-         * {@code Optional#empty()} if {@code tagsToRemove} is null.
+         * Returns an unmodifiable tag set to remove, which throws {@code UnsupportedOperationException} if modification
+         * is attempted. Returns {@code Optional#empty()} if {@code tagsToRemove} is null.
          */
         public Optional<Set<StudyGroupTag>> getTagsToRemove() {
             return (tagsToRemove != null)

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -14,8 +14,8 @@ import seedu.address.model.Model;
 import seedu.address.model.person.predicates.PredicateGroup;
 
 /**
- * Finds and lists all persons in address book whose field(s) satisfy all
- * criteria provided. Criteria are given in a {@code PredicateGroup}.
+ * Finds and lists all persons in address book whose field(s) satisfy all criteria provided. Criteria are given in a
+ * {@code PredicateGroup}.
  */
 public class FindCommand extends Command {
 
@@ -30,7 +30,7 @@ public class FindCommand extends Command {
             + "[" + PREFIX_GENDER + "GENDER ...] "
             + "[" + PREFIX_AGE + "AGE ...] "
             + "[" + PREFIX_DETAIL + "DETAIL ...]"
-            + "[" + PREFIX_STUDY_GROUP_TAG + "STUDY_GROUP_TAG ...]\n"
+            + "[" + PREFIX_STUDY_GROUP_TAG + "STUDY-GROUP-TAG ...]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "alice bob charlie";
 
     public static final String MESSAGE_NO_CRITERIA = "Provide at least one criteria to find!";

--- a/src/main/java/seedu/address/model/tag/StudyGroupTag.java
+++ b/src/main/java/seedu/address/model/tag/StudyGroupTag.java
@@ -4,17 +4,17 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a StudyGroupTag in the address book. Guarantees: immutable; name
- * is valid as declared in {@link #isValidStudyGroupName(String)}
+ * Represents a StudyGroupTag in the address book. Guarantees: immutable; name is valid as declared in
+ * {@link #isValidStudyGroupName(String)}
  */
 public class StudyGroupTag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Study group names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS = "Study group names should only contain alphanumeric characters and dashes";
 
     /*
      * The study group name must be alphanumeric.
      */
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}-]+";
 
     public final String studyGroupName;
 

--- a/src/main/java/seedu/address/model/tag/StudyGroupTag.java
+++ b/src/main/java/seedu/address/model/tag/StudyGroupTag.java
@@ -9,7 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class StudyGroupTag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Study group names should only contain alphanumeric characters and dashes";
+    public static final String MESSAGE_CONSTRAINTS = "Study group names should only contain alphanumeric "
+            + "characters and dashes";
 
     /*
      * The study group name must be alphanumeric.


### PR DESCRIPTION
Fixes #124

Study group names only accept alphanumeric characters. Let's also accept dashes "-" to increase the expressiveness of study group tags.

#### Affected commands:
**Add:** `add ... t/P90-Control`
**Edit:** `edit 1 t/P90-Experimental -t/P90-Control`
**Find:** `find t/P90-Control P90-Experimental`