### PR TITLE
Fix StudyGroupTag equals function

### DIFF
--- a/src/main/java/seedu/address/model/tag/StudyGroupTag.java
+++ b/src/main/java/seedu/address/model/tag/StudyGroupTag.java
@@ -49,7 +49,7 @@ public class StudyGroupTag {
         }
 
         StudyGroupTag otherTag = (StudyGroupTag) other;
-        return studyGroupName.equals(otherTag.studyGroupName);
+        return studyGroupName.toLowerCase().equals(otherTag.studyGroupName.toLowerCase());
     }
 
     @Override

--- a/src/test/java/seedu/address/model/tag/StudyGroupTagTest.java
+++ b/src/test/java/seedu/address/model/tag/StudyGroupTagTest.java
@@ -1,10 +1,35 @@
 package seedu.address.model.tag;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 public class StudyGroupTagTest {
+
+    @Test
+    public void equals() {
+        StudyGroupTag studyGroupTag = new StudyGroupTag("case");
+
+        // same values -> returns true
+        assertTrue(studyGroupTag.equals(new StudyGroupTag("case")));
+
+        // different case -> returns true
+        assertTrue(studyGroupTag.equals(new StudyGroupTag("CaSe")));
+
+        // same object -> returns true
+        assertTrue(studyGroupTag.equals(studyGroupTag));
+
+        // null -> returns false
+        assertFalse(studyGroupTag.equals(null));
+
+        // different types -> returns false
+        assertFalse(studyGroupTag.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(studyGroupTag.equals(new StudyGroupTag("Other-Study-Group-Name")));
+    }
 
     @Test
     public void constructor_null_throwsNullPointerException() {


### PR DESCRIPTION
Fixes #147 
Change `StudyGroupTag::equals` function to compare case-insensitively.