### PR TITLE
Add message for no participants to clear

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -2,7 +2,9 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import javafx.collections.ObservableList;
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 
 /**
  * Makes the address book ready for clearing and prompts for confirmation to clear.
@@ -10,8 +12,10 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_CHECK = "Type confirm to clear listed participants \n"
-                                                + "Type anything else to cancel clearing";
+    public static final String MESSAGE_EMPTY = "No participants to clear.";
+
+    public static final String MESSAGE_CHECK = "Type confirm to clear listed participants. \n"
+                                                + "Type anything else to cancel clearing.";
     private static boolean isClear;
 
 
@@ -26,6 +30,10 @@ public class ClearCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        ObservableList<Person> contactsList = model.getFilteredPersonList();
+        if (contactsList.isEmpty()) {
+            return new CommandResult(MESSAGE_EMPTY);
+        }
         ClearCommand.setIsClear(true);
         return new CommandResult(MESSAGE_CHECK);
     }

--- a/src/main/java/seedu/address/logic/commands/ConfirmClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ConfirmClearCommand.java
@@ -15,8 +15,8 @@ import seedu.address.model.person.Person;
 public class ConfirmClearCommand extends Command {
 
     public static final String COMMAND_WORD = "confirm";
-    public static final String MESSAGE_SUCCESS_FULL_CLEAR = "Address book has been cleared";
-    public static final String MESSAGE_SUCCESS_FILTERED_CLEAR = "Filtered participants have been deleted";
+    public static final String MESSAGE_SUCCESS_FULL_CLEAR = "Address book has been cleared.";
+    public static final String MESSAGE_SUCCESS_FILTERED_CLEAR = "Filtered participants have been deleted.";
 
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,19 +1,35 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 
 public class ClearCommandTest {
 
+    private Model model;
+    private Model expectedModel;
+
     @Test
-    public void execute_clearPromptsConfirmationCheck_success() {
-        Model model = new ModelManager();
-        Model expectedModel = new ModelManager();
+    public void execute_emptyListClearPromptsConfirmationCheck_success() {
+        model = new ModelManager();
+        expectedModel = new ModelManager();
+        ClearCommand.setIsClear(false);
+
+        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_EMPTY, expectedModel);
+        assertFalse(ClearCommand.getIsClear());
+    }
+
+    @Test
+    public void execute_nonEmptyListClearPromptsConfirmationCheck_success() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());;
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         ClearCommand.setIsClear(false);
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_CHECK, expectedModel);


### PR DESCRIPTION
When there are no participants listed to clear, there will be a message: "No participants to clear." instead of a message requesting for confirmation. Typing confirm after this will be invalid.