### PR TITLE
Update incorrect constaint on age integer field

### DIFF
--- a/src/main/java/seedu/address/model/person/Age.java
+++ b/src/main/java/seedu/address/model/person/Age.java
@@ -27,7 +27,7 @@ public class Age {
     public Age(String age) {
         requireNonNull(age);
         checkArgument(isValidAge(age), MESSAGE_CONSTRAINTS);
-        this.value = age;
+        this.value = age.replaceFirst("0{0," + (age.length() - 1) + "}", "");
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/predicates/AgeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/AgeContainsKeywordsPredicate.java
@@ -17,7 +17,8 @@ import seedu.address.model.person.Person;
 public class AgeContainsKeywordsPredicate implements Predicate<Person> {
     public static final String VALIDATION_REGEX = "\\d+|(\\d+-\\d+)";
     public static final String MESSAGE_CONSTRAINTS = "Each age criteria should contain non-negative integers, "
-            + "in the format 'number' or 'number-number'!\n"
+            + "between 0 and 150 (inclusive),\n"
+            + "and be in the format 'number' or 'number-number'!\n"
             + "Example: a/23 30-34";
 
     private static final Pattern RANGE_PATTERN = Pattern.compile("(\\d+)-(\\d+)");
@@ -43,8 +44,22 @@ public class AgeContainsKeywordsPredicate implements Predicate<Person> {
     public static boolean isValidInput(String test) {
         if (!test.matches(VALIDATION_REGEX)) {
             return false;
+        } else {
+            var matcher = RANGE_PATTERN.matcher(test);
+            if (matcher.matches()) {
+                try {
+                    return Integer.parseInt(matcher.group(1)) <= 150
+                            && Integer.parseInt(matcher.group(1)) >= 0
+                            && Integer.parseInt(matcher.group(2)) <= 150
+                            && Integer.parseInt(matcher.group(2)) >= 0;
+                } catch (NumberFormatException e) {
+                    return false;
+                }
+            } else {
+                return Integer.parseInt(test) <= 150 && Integer.parseInt(test) >= 0;
+            }
         }
-        return true;
+
     }
 
     @Override
@@ -59,7 +74,8 @@ public class AgeContainsKeywordsPredicate implements Predicate<Person> {
                 return age >= lowerBound && age <= upperBound;
             } else {
                 // Check for individual age
-                return StringUtil.containsWordIgnoreCase(String.valueOf(age), keyword);
+                return StringUtil.containsWordIgnoreCase(String.valueOf(age),
+                        keyword.replaceFirst("0{0," + (keyword.length() - 1) + "}", ""));
             }
         });
     }

--- a/src/main/java/seedu/address/model/person/predicates/AgeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/AgeContainsKeywordsPredicate.java
@@ -17,7 +17,7 @@ import seedu.address.model.person.Person;
 public class AgeContainsKeywordsPredicate implements Predicate<Person> {
     public static final String VALIDATION_REGEX = "\\d+|(\\d+-\\d+)";
     public static final String MESSAGE_CONSTRAINTS = "Each age criteria should contain non-negative integers, "
-            + "between 0 and 150 (inclusive),\n"
+            + "between 0 and 150 (both inclusive),\n"
             + "and be in the format 'number' or 'number-number'!\n"
             + "Example: a/23 30-34";
 

--- a/src/test/java/seedu/address/model/person/AgeTest.java
+++ b/src/test/java/seedu/address/model/person/AgeTest.java
@@ -38,6 +38,8 @@ public class AgeTest {
         assertTrue(Age.isValidAge("27")); // between lower and upper limit
         assertTrue(Age.isValidAge("0")); // lower limit
         assertTrue(Age.isValidAge("150")); // upper limit
+        assertTrue(Age.isValidAge("00001")); // leading zero input
+        assertTrue(Age.isValidAge("00000")); // leading zero input with value 0
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/predicates/AgeContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/AgeContainsKeywordsPredicateTest.java
@@ -45,6 +45,8 @@ public class AgeContainsKeywordsPredicateTest {
         assertTrue(AgeContainsKeywordsPredicate.isValidInput("27")); // between lower and upper limit
         assertTrue(AgeContainsKeywordsPredicate.isValidInput("1-4")); // a range
         assertTrue(AgeContainsKeywordsPredicate.isValidInput("4-1")); // reverse order range
+        assertTrue(AgeContainsKeywordsPredicate.isValidInput("00001")); // zero padded input
+        assertTrue(AgeContainsKeywordsPredicate.isValidInput("00000")); // zero padded input with value 0
     }
 
     @Test
@@ -127,6 +129,30 @@ public class AgeContainsKeywordsPredicateTest {
         predicate = new AgeContainsKeywordsPredicate(
                 Set.of("9-10", "12-14"));
         assertFalse(predicate.test(new PersonBuilder().withAge("11").build()));
+    }
+
+    @Test
+    public void test_ageContainsInputWithLeadingZeros_returnsTrue() {
+        // leading zeros input
+        AgeContainsKeywordsPredicate predicate = new AgeContainsKeywordsPredicate(
+                Set.of("00001"));
+        assertTrue(predicate.test(new PersonBuilder().withAge("1").build()));
+
+        // leading zeros input with value 0
+        predicate = new AgeContainsKeywordsPredicate(
+                Set.of("00000"));
+        assertTrue(predicate.test(new PersonBuilder().withAge("0").build()));
+
+        // leading zeros range
+        predicate = new AgeContainsKeywordsPredicate(
+                Set.of("00001-2"));
+        assertTrue(predicate.test(new PersonBuilder().withAge("1").build()));
+        predicate = new AgeContainsKeywordsPredicate(
+                Set.of("1-00002"));
+        assertTrue(predicate.test(new PersonBuilder().withAge("2").build()));
+        predicate = new AgeContainsKeywordsPredicate(
+                Set.of("00001-00002"));
+        assertTrue(predicate.test(new PersonBuilder().withAge("1").build()));
     }
 
     @Test


### PR DESCRIPTION
Fixes #298, fixes #292, fixes #255

The find command cannot handle large integers in ranges.

The age field does not properly handle inputs with leading zeros for all relevant commands, and will use the "unsuitable" input to process an (incorrect) output.

Let's do the following:
- Parse all keyword inputs to check for invalid ages (large numbers or out of bound)
- Strip leading zeros from all age inputs before using them