### PR TITLE
Code standardization - Fix coding standard violation (naming)

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -54,7 +54,7 @@ public class MainWindow extends UiPart<Stage> {
     private StackPane resultDisplayPlaceholder;
 
     @FXML
-    private StackPane statusbarPlaceholder;
+    private StackPane statusBarPlaceholder;
 
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
@@ -141,7 +141,7 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
-        statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
+        statusBarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -67,7 +67,7 @@
         </HBox>
 
         <!-- Status bar at the bottom -->
-        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER">
+        <StackPane fx:id="statusBarPlaceholder" VBox.vgrow="NEVER">
         </StackPane>
       </VBox>
     </Scene>


### PR DESCRIPTION
Fixes #315 

`statusbarPlaceholder` is now spelt as `statusBarPlaceholder`.